### PR TITLE
With frame caching

### DIFF
--- a/benchmarks.md
+++ b/benchmarks.md
@@ -14,36 +14,36 @@ Comparisons relevant within zerrors only.
 
 ```
 # zerrors.Wrap
-BenchmarkWrappingError_Error/Wrap/depth-1-4 	            13254200	      87.6 ns/op	      16 B/op	       1 allocs/op
-BenchmarkWrappingError_Error/Wrap/depth-2-4 	            10297276	       111 ns/op	      32 B/op	       1 allocs/op
-BenchmarkWrappingError_Error/Wrap/depth-3-4 	             8879667	       133 ns/op	      32 B/op	       1 allocs/op
-BenchmarkWrappingError_Error/Wrap/depth-5-4 	             6529983	       181 ns/op	      64 B/op	       1 allocs/op
-BenchmarkWrappingError_Error/Wrap/depth-10-4         	     3885102	       304 ns/op	      96 B/op	       1 allocs/op
-BenchmarkWrappingError_Error/Wrap/depth-20-4         	     2222133	       539 ns/op	     192 B/op	       1 allocs/op
+BenchmarkWrappingError_Error/Wrap/depth-1-4 	        13298210      85.8 ns/op      16 B/op    1 allocs/op
+BenchmarkWrappingError_Error/Wrap/depth-2-4 	        10205412       114 ns/op      32 B/op    1 allocs/op
+BenchmarkWrappingError_Error/Wrap/depth-3-4 	         8872419       131 ns/op      32 B/op    1 allocs/op
+BenchmarkWrappingError_Error/Wrap/depth-5-4 	         6203349       184 ns/op      64 B/op    1 allocs/op
+BenchmarkWrappingError_Error/Wrap/depth-10-4         	 3828380       310 ns/op      96 B/op    1 allocs/op
+BenchmarkWrappingError_Error/Wrap/depth-20-4         	 2165709       550 ns/op     192 B/op    1 allocs/op
 
 # zerrors.Wrap, with Frame
-BenchmarkWrappingError_Error/Wrap_WithFrame/depth-1-4      	 1378066	       866 ns/op	     480 B/op	       3 allocs/op
-BenchmarkWrappingError_Error/Wrap_WithFrame/depth-2-4      	  891384	      1354 ns/op	     736 B/op	       4 allocs/op
-BenchmarkWrappingError_Error/Wrap_WithFrame/depth-3-4      	  618862	      1847 ns/op	     976 B/op	       5 allocs/op
-BenchmarkWrappingError_Error/Wrap_WithFrame/depth-5-4      	  412141	      2703 ns/op	    1456 B/op	       7 allocs/op
-BenchmarkWrappingError_Error/Wrap_WithFrame/depth-10-4     	  232555	      4978 ns/op	    2672 B/op	      12 allocs/op
-BenchmarkWrappingError_Error/Wrap_WithFrame/depth-20-4     	  121351	      9485 ns/op	    5136 B/op	      22 allocs/op
+BenchmarkWrappingError_Error/Wrap_WithFrame/depth-1-4  	 3954945       301 ns/op      64 B/op    1 allocs/op
+BenchmarkWrappingError_Error/Wrap_WithFrame/depth-2-4  	 2773854       425 ns/op     112 B/op    1 allocs/op
+BenchmarkWrappingError_Error/Wrap_WithFrame/depth-3-4  	 2097567       574 ns/op     144 B/op    1 allocs/op
+BenchmarkWrappingError_Error/Wrap_WithFrame/depth-5-4  	 1442390       826 ns/op     208 B/op    1 allocs/op
+BenchmarkWrappingError_Error/Wrap_WithFrame/depth-10-4 	  713192      1492 ns/op     384 B/op    1 allocs/op
+BenchmarkWrappingError_Error/Wrap_WithFrame/depth-20-4 	  412788      2740 ns/op     768 B/op    1 allocs/op
 
 # zerrors.SWrap
-BenchmarkWrappingError_Error/SWrap/depth-1-4               	13419445	      88.5 ns/op	      16 B/op	       1 allocs/op
-BenchmarkWrappingError_Error/SWrap/depth-2-4               	10583445	       112 ns/op	      32 B/op	       1 allocs/op
-BenchmarkWrappingError_Error/SWrap/depth-3-4               	 8643290	       131 ns/op	      32 B/op	       1 allocs/op
-BenchmarkWrappingError_Error/SWrap/depth-5-4               	 6458634	       180 ns/op	      64 B/op	       1 allocs/op
-BenchmarkWrappingError_Error/SWrap/depth-10-4              	 3882927	       305 ns/op	      96 B/op	       1 allocs/op
-BenchmarkWrappingError_Error/SWrap/depth-20-4              	 2189319	       538 ns/op	     192 B/op	       1 allocs/op
+BenchmarkWrappingError_Error/SWrap/depth-1-4           	13501796      84.6 ns/op      16 B/op    1 allocs/op
+BenchmarkWrappingError_Error/SWrap/depth-2-4           	10289352       111 ns/op      32 B/op    1 allocs/op
+BenchmarkWrappingError_Error/SWrap/depth-3-4           	 8860008       130 ns/op      32 B/op    1 allocs/op
+BenchmarkWrappingError_Error/SWrap/depth-5-4           	 6490771       185 ns/op      64 B/op    1 allocs/op
+BenchmarkWrappingError_Error/SWrap/depth-10-4          	 3861034       306 ns/op      96 B/op    1 allocs/op
+BenchmarkWrappingError_Error/SWrap/depth-20-4          	 2205504       556 ns/op     192 B/op    1 allocs/op
 
 # zerrors.SWrap, with Frame
-BenchmarkWrappingError_Error/SWrap_WithFrame/depth-1-4     	 1683946	       722 ns/op	     480 B/op	       3 allocs/op
-BenchmarkWrappingError_Error/SWrap_WithFrame/depth-2-4     	 1000000	      1056 ns/op	     736 B/op	       4 allocs/op
-BenchmarkWrappingError_Error/SWrap_WithFrame/depth-3-4     	  706592	      1423 ns/op	     976 B/op	       5 allocs/op
-BenchmarkWrappingError_Error/SWrap_WithFrame/depth-5-4     	  537345	      2144 ns/op	    1456 B/op	       7 allocs/op
-BenchmarkWrappingError_Error/SWrap_WithFrame/depth-10-4    	  278078	      3873 ns/op	    2672 B/op	      12 allocs/op
-BenchmarkWrappingError_Error/SWrap_WithFrame/depth-20-4    	  165957	      7318 ns/op	    5136 B/op	      22 allocs/op
+BenchmarkWrappingError_Error/SWrap_WithFrame/depth-1-4 	 4068465       292 ns/op      64 B/op    1 allocs/op
+BenchmarkWrappingError_Error/SWrap_WithFrame/depth-2-4 	 2827851       420 ns/op     112 B/op    1 allocs/op
+BenchmarkWrappingError_Error/SWrap_WithFrame/depth-3-4 	 2117974       561 ns/op     144 B/op    1 allocs/op
+BenchmarkWrappingError_Error/SWrap_WithFrame/depth-5-4 	 1484380       803 ns/op     208 B/op    1 allocs/op
+BenchmarkWrappingError_Error/SWrap_WithFrame/depth-10-4	  814632      1468 ns/op     384 B/op    1 allocs/op
+BenchmarkWrappingError_Error/SWrap_WithFrame/depth-20-4	  398394      2753 ns/op     768 B/op    1 allocs/op
 ```
 
 ## External benchmarks
@@ -54,50 +54,50 @@ Except for frames, which carry additional information.
 
 ```
 # zerrors.Wrap
-BenchmarkCreateAndError/Wrap/depth-1-4                  4938819	       238 ns/op	     112 B/op	       5 allocs/op
-BenchmarkCreateAndError/Wrap/depth-2-4                  3412208	       342 ns/op	     176 B/op	       7 allocs/op
-BenchmarkCreateAndError/Wrap/depth-3-4                  2678944	       444 ns/op	     224 B/op	       9 allocs/op
-BenchmarkCreateAndError/Wrap/depth-5-4                  1854499	       654 ns/op	     352 B/op	      13 allocs/op
-BenchmarkCreateAndError/Wrap/depth-10-4                 1036364	      1148 ns/op	     624 B/op	      23 allocs/op
-BenchmarkCreateAndError/Wrap/depth-20-4                  541490	      2137 ns/op	    1200 B/op	      43 allocs/op
+BenchmarkCreateAndError/Wrap/depth-1-4                 	 4844085       246 ns/op     112 B/op    5 allocs/op
+BenchmarkCreateAndError/Wrap/depth-2-4                 	 3426805       346 ns/op     176 B/op    7 allocs/op
+BenchmarkCreateAndError/Wrap/depth-3-4                 	 2607721       455 ns/op     224 B/op    9 allocs/op
+BenchmarkCreateAndError/Wrap/depth-5-4                 	 1874023       643 ns/op     352 B/op   13 allocs/op
+BenchmarkCreateAndError/Wrap/depth-10-4                	 1000000      1164 ns/op     624 B/op   23 allocs/op
+BenchmarkCreateAndError/Wrap/depth-20-4                	  489519      2165 ns/op    1200 B/op   43 allocs/op
 
 # zerrors.Wrap, with Frame
-BenchmarkCreateAndError/Wrap_WithFrame/depth-1-4         651660	      1819 ns/op	     576 B/op	       7 allocs/op
-BenchmarkCreateAndError/Wrap_WithFrame/depth-2-4         418525	      2759 ns/op	     880 B/op	      10 allocs/op
-BenchmarkCreateAndError/Wrap_WithFrame/depth-3-4         322153	      3717 ns/op	    1168 B/op	      13 allocs/op
-BenchmarkCreateAndError/Wrap_WithFrame/depth-5-4         211983	      5538 ns/op	    1744 B/op	      19 allocs/op
-BenchmarkCreateAndError/Wrap_WithFrame/depth-10-4        115669	     10208 ns/op	    3200 B/op	      34 allocs/op
-BenchmarkCreateAndError/Wrap_WithFrame/depth-20-4         62293	     19184 ns/op	    6145 B/op	      64 allocs/op
+BenchmarkCreateAndError/Wrap_WithFrame/depth-1-4       	  988268      1215 ns/op     160 B/op    5 allocs/op
+BenchmarkCreateAndError/Wrap_WithFrame/depth-2-4       	  565093      1826 ns/op     256 B/op    7 allocs/op
+BenchmarkCreateAndError/Wrap_WithFrame/depth-3-4       	  476220      2418 ns/op     336 B/op    9 allocs/op
+BenchmarkCreateAndError/Wrap_WithFrame/depth-5-4       	  320095      3554 ns/op     496 B/op   13 allocs/op
+BenchmarkCreateAndError/Wrap_WithFrame/depth-10-4      	  180004      6413 ns/op     912 B/op   23 allocs/op
+BenchmarkCreateAndError/Wrap_WithFrame/depth-20-4      	   97352     12166 ns/op    1776 B/op   43 allocs/op
 
 # zerrors.SWrap
-BenchmarkCreateAndError/SWrap/depth-1-4                 6355956	       194 ns/op	     112 B/op	       3 allocs/op
-BenchmarkCreateAndError/SWrap/depth-2-4                 4132869	       273 ns/op	     176 B/op	       4 allocs/op
-BenchmarkCreateAndError/SWrap/depth-3-4                 3511677	       345 ns/op	     224 B/op	       5 allocs/op
-BenchmarkCreateAndError/SWrap/depth-5-4                 2319687	       525 ns/op	     352 B/op	       7 allocs/op
-BenchmarkCreateAndError/SWrap/depth-10-4                1308480	       909 ns/op	     624 B/op	      12 allocs/op
-BenchmarkCreateAndError/SWrap/depth-20-4                 690384	      1696 ns/op	    1200 B/op	      22 allocs/op
+BenchmarkCreateAndError/SWrap/depth-1-4                	 6000632       198 ns/op     112 B/op    3 allocs/op
+BenchmarkCreateAndError/SWrap/depth-2-4                	 4334427       281 ns/op     176 B/op    4 allocs/op
+BenchmarkCreateAndError/SWrap/depth-3-4                	 3434900       347 ns/op     224 B/op    5 allocs/op
+BenchmarkCreateAndError/SWrap/depth-5-4                	 2336950       510 ns/op     352 B/op    7 allocs/op
+BenchmarkCreateAndError/SWrap/depth-10-4               	 1297386       916 ns/op     624 B/op   12 allocs/op
+BenchmarkCreateAndError/SWrap/depth-20-4               	  662431      1695 ns/op    1200 B/op   22 allocs/op
 
 # zerrors.SWrap, with Frame
-BenchmarkCreateAndError/SWrap_WithFrame/depth-1-4        770977	      1450 ns/op	     576 B/op	       5 allocs/op
-BenchmarkCreateAndError/SWrap_WithFrame/depth-2-4        523915	      2165 ns/op	     880 B/op	       7 allocs/op
-BenchmarkCreateAndError/SWrap_WithFrame/depth-3-4        400105	      2876 ns/op	    1168 B/op	       9 allocs/op
-BenchmarkCreateAndError/SWrap_WithFrame/depth-5-4        272775	      4335 ns/op	    1744 B/op	      13 allocs/op
-BenchmarkCreateAndError/SWrap_WithFrame/depth-10-4       151970	      7787 ns/op	    3200 B/op	      23 allocs/op
-BenchmarkCreateAndError/SWrap_WithFrame/depth-20-4        81220	     14978 ns/op	    6145 B/op	      43 allocs/op
+BenchmarkCreateAndError/SWrap_WithFrame/depth-1-4      	 1000000      1015 ns/op     160 B/op    3 allocs/op
+BenchmarkCreateAndError/SWrap_WithFrame/depth-2-4      	  671530      1534 ns/op     256 B/op    4 allocs/op
+BenchmarkCreateAndError/SWrap_WithFrame/depth-3-4      	  557664      2042 ns/op     336 B/op    5 allocs/op
+BenchmarkCreateAndError/SWrap_WithFrame/depth-5-4      	  340326      2963 ns/op     496 B/op    7 allocs/op
+BenchmarkCreateAndError/SWrap_WithFrame/depth-10-4     	  208437      5323 ns/op     912 B/op   12 allocs/op
+BenchmarkCreateAndError/SWrap_WithFrame/depth-20-4     	  115428     10040 ns/op    1776 B/op   22 allocs/op
 
 # fmt.Errorf
-BenchmarkCreateAndError/fmt_Errorf/depth-1-4            3987376	       302 ns/op	      64 B/op	       3 allocs/op
-BenchmarkCreateAndError/fmt_Errorf/depth-2-4            2114754	       566 ns/op	     128 B/op	       5 allocs/op
-BenchmarkCreateAndError/fmt_Errorf/depth-3-4            1420866	       843 ns/op	     192 B/op	       7 allocs/op
-BenchmarkCreateAndError/fmt_Errorf/depth-5-4             774889	      1402 ns/op	     368 B/op	      11 allocs/op
-BenchmarkCreateAndError/fmt_Errorf/depth-10-4            406684	      2837 ns/op	     944 B/op	      21 allocs/op
-BenchmarkCreateAndError/fmt_Errorf/depth-20-4            199404	      6033 ns/op	    2768 B/op	      41 allocs/op
+BenchmarkCreateAndError/fmt_Errorf/depth-1-4           	 3911899       302 ns/op      64 B/op    3 allocs/op
+BenchmarkCreateAndError/fmt_Errorf/depth-2-4           	 2109055       566 ns/op     128 B/op    5 allocs/op
+BenchmarkCreateAndError/fmt_Errorf/depth-3-4           	 1426414       837 ns/op     192 B/op    7 allocs/op
+BenchmarkCreateAndError/fmt_Errorf/depth-5-4           	  797191      1396 ns/op     368 B/op   11 allocs/op
+BenchmarkCreateAndError/fmt_Errorf/depth-10-4          	  405751      2826 ns/op     944 B/op   21 allocs/op
+BenchmarkCreateAndError/fmt_Errorf/depth-20-4          	  195168      5940 ns/op    2768 B/op   41 allocs/op
 
 # errors.New
-BenchmarkCreateAndError/errors_New/depth-1-4            9212372	       118 ns/op	      48 B/op	       3 allocs/op
-BenchmarkCreateAndError/errors_New/depth-2-4            5857843	       205 ns/op	      96 B/op	       5 allocs/op
-BenchmarkCreateAndError/errors_New/depth-3-4            4079690	       294 ns/op	     144 B/op	       7 allocs/op
-BenchmarkCreateAndError/errors_New/depth-5-4            2411808	       504 ns/op	     288 B/op	      11 allocs/op
-BenchmarkCreateAndError/errors_New/depth-10-4            984384	      1062 ns/op	     784 B/op	      21 allocs/op
-BenchmarkCreateAndError/errors_New/depth-20-4            492328	      2282 ns/op	    2448 B/op	      41 allocs/op
+BenchmarkCreateAndError/errors_New/depth-1-4           	 9423854       116 ns/op      48 B/op    3 allocs/op
+BenchmarkCreateAndError/errors_New/depth-2-4           	 5731902       204 ns/op      96 B/op    5 allocs/op
+BenchmarkCreateAndError/errors_New/depth-3-4           	 4211803       286 ns/op     144 B/op    7 allocs/op
+BenchmarkCreateAndError/errors_New/depth-5-4           	 2313610       485 ns/op     288 B/op   11 allocs/op
+BenchmarkCreateAndError/errors_New/depth-10-4          	 1000000      1042 ns/op     784 B/op   21 allocs/op
+BenchmarkCreateAndError/errors_New/depth-20-4          	  514698      2240 ns/op    2448 B/op   41 allocs/op
 ```

--- a/internal/env.go
+++ b/internal/env.go
@@ -15,16 +15,131 @@
 // Package internal contains stateful global variables internal to zerrors.
 package internal
 
-var frameCapture = false
+import (
+	"runtime"
+	"sync"
+	"sync/atomic"
+)
 
-// SetFrameCapture is only used in zmain, and in testing.
+var (
+	// frameCapture may be set to true during init phase, but never after (except in internal tests).
+	frameCapture = false
+
+	// linkerFrameCapture is a linker alternative to zmain to manipulate frameCapture.
+	// If 'true', frameCapture is enabled regardless of zmain import.
+	// If 'false', frameCapture is disabled regardless of zmain import.
+	// Any other value is ignored.
+	linkerFrameCapture string
+
+	once    sync.Once
+	cache   atomic.Value              // The underlying type is *map[uintptr]runtime.Frame
+	current map[uintptr]runtime.Frame // The same as cache above, but split to avoid atomic access. Read-only.
+	next    map[uintptr]runtime.Frame // Eventually becomes current. It is read-write and not shared.
+	updates chan struct {
+		pc    uintptr
+		frame runtime.Frame
+	} // The means by which new entries make it into the cache.
+
+	updatesCount = 0
+)
+
+const (
+	// Used to control how often 'next' is promoted to 'current'.
+	// The value is arbitrary.
+	updatesBeforeCacheSwitch = 10
+)
+
+func init() {
+	if linkerFrameCapture == "true" {
+		// Set by the linker.
+		SetFrameCapture()
+	}
+}
+
+func initCache() {
+	updates = make(chan struct {
+		pc    uintptr
+		frame runtime.Frame
+	}, 10)
+	storeCache(make(map[uintptr]runtime.Frame))
+
+	go runCacheLoop()
+}
+
+func storeCache(v map[uintptr]runtime.Frame) {
+	current = v
+	cache.Store(&v)
+}
+
+func runCacheLoop() {
+	for update := range updates {
+		// Checking 'current' not 'next' so that repeated use of the same frame does eventually lead to the promotion of 'next'.
+		if _, ok := current[update.pc]; ok {
+			continue
+		}
+
+		if next == nil {
+			next = make(map[uintptr]runtime.Frame, len(current)+updatesBeforeCacheSwitch)
+			for k, v := range current {
+				next[k] = v
+			}
+		}
+
+		next[update.pc] = update.frame
+
+		updatesCount++
+
+		if updatesCount > updatesBeforeCacheSwitch {
+			storeCache(next)
+			next = nil
+			updatesCount = 0
+		}
+	}
+}
+
+// GetFramer returns a Framer with the latest global runtime.Frame cache.
+func GetFramer() Framer {
+	return *(cache.Load().(*map[uintptr]runtime.Frame))
+}
+
+// Framer is a runtime.Frame cache.
+type Framer map[uintptr]runtime.Frame
+
+// Get gets a frame from the cache, and if not found it evaluates it, stores it in the cache and returns.
+func (f Framer) Get(pc uintptr) runtime.Frame {
+	if frame, ok := f[pc]; ok {
+		return frame
+	}
+
+	callers := [1]uintptr{pc}
+	frame, _ := runtime.CallersFrames(callers[:]).Next()
+
+	select {
+	case updates <- struct {
+		pc    uintptr
+		frame runtime.Frame
+	}{pc, frame}:
+	default:
+		// Do not block.
+	}
+
+	return frame
+}
+
+// SetFrameCapture is only used in zmain's init func and in testing.
 func SetFrameCapture() {
+	if linkerFrameCapture == "false" {
+		return
+	}
+	once.Do(initCache)
 	frameCapture = true
 }
 
 // UnsetFrameCapture is only used in testing.
 func UnsetFrameCapture() {
-	frameCapture = false
+	if linkerFrameCapture != "true" {
+		frameCapture = false
+	}
 }
 
 // GetFrameCapture is a getter for frameCapture.


### PR DESCRIPTION
Frame evaluation (converting from the uintptr to line,file, etc) is cached in a global internal cache for improved performance.